### PR TITLE
Escape class name as well as method name in regex

### DIFF
--- a/lib/minitest/bisect.rb
+++ b/lib/minitest/bisect.rb
@@ -199,16 +199,20 @@ class Minitest::Bisect
 
     bbc.each do |klass, methods|
       methods = methods.map(&:last).flatten.uniq.map { |method|
-        method.gsub(/([`'"!?&\[\]\(\)\|\+])/, '\\\\\1')
+        re_escape method
       }
 
       methods = methods.join "|"
-      re << /#{klass}#(?:#{methods})/.to_s[7..-2] # (?-mix:...)
+      re << /#{re_escape klass}#(?:#{methods})/.to_s[7..-2] # (?-mix:...)
     end
 
     re = re.join("|").to_s.gsub(/-mix/, "")
 
     "/^(?:#{re})$/"
+  end
+
+  def re_escape str
+    str.gsub(/([`'"!?&\[\]\(\)\{\}\|\+])/, '\\\\\1')
   end
 
   def build_methods_cmd cmd, culprits = [], bad = nil

--- a/test/minitest/test_bisect.rb
+++ b/test/minitest/test_bisect.rb
@@ -90,7 +90,15 @@ class TestMinitest::TestBisect < Minitest::Test
     assert_equal exp, bisect.build_re(bad)
   end
 
-  def test_build_re_escaping
+  def test_build_re_class_escaping
+    bad = ["{}#[]"]
+
+    exp = "/^(?:\\{\\}#(?:\\[\\]))$/"
+
+    assert_equal exp, bisect.build_re(bad)
+  end
+
+  def test_build_re_method_escaping
     bad = ["Some Class#It shouldn't care what the name is"]
 
     exp = "/^(?:Some Class#(?:It shouldn\\'t care what the name is))$/"


### PR DESCRIPTION
While bisecting a failure on Rails, I hit https://github.com/rails/rails/blob/38f9e41f2c4b64377ffb036c53873dbfb51546cf/activerecord/test/cases/arel/table_test.rb#L187, which resulted in:

`empty char-class: /[]::when given a Symbol#(?:test_0001_manufactures an attribute if the symbol names an attribute within the relation)/`

I've gone with the smaller self-contained change here, though I wonder whether `build_re` could/should be using `Regexp.escape` and/or `Regexp.union`